### PR TITLE
Fixed token refresh on expiry

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -224,7 +224,7 @@ func (o *OAuthTokenClient) GetJWT() (string, error) {
 
 	claims.Validate(&vr)
 
-	if len(vr.Errors()) != 0 {
+	if vr.IsBlocking(true) {
 		// Regenerate the token
 		err := o.generateJWT(ctx)
 


### PR DESCRIPTION
An expired token isn't actually considered an "Error" so I'm changing the logic to catch expiries as "blocking" errors